### PR TITLE
Parse/glob/interpret files like other editorconfig implementations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests"]
+	path = tests
+	url = git://github.com/editorconfig/editorconfig-core-test.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ script:
   - cargo build --verbose
   - cargo test --verbose
   - cd tests
-  - cmake -DEDITORCONFIG_CMD=`pwd`/../target/debug/editorconfig -E $(cat ../test_skip_regex.txt) .
-  - ctest .
+  - cmake -DEDITORCONFIG_CMD=`pwd`/../target/debug/editorconfig .
+  - ctest . -E $(cat ../test_skip_regex.txt)

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ script:
   - cargo build --verbose
   - cargo test --verbose
   - cd tests
-  - cmake -DEDITORCONFIG_CMD=`pwd`/../target/debug/editorconfig . -E $(cat test_skip_regex.txt)
+  - cmake -DEDITORCONFIG_CMD=`pwd`/../target/debug/editorconfig . -E $(cat ../test_skip_regex.txt)
   - ctest .

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,9 @@ rust:
 matrix:
   allow_failures:
     - rust: nightly
+script:
+  - cargo build --verbose
+  - cargo test --verbose
+  - cd tests
+  - cmake -DEDITORCONFIG_CMD=`pwd`/../target/debug/editorconfig . -E $(cat test_skip_regex.txt)
+  - ctest .

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,16 @@ rust:
   - stable
   - beta
   - nightly
+env:
+  - SKIP_TESTS_FROM=../test_skip_regex.txt
+  - SKIP_TESTS_FROM=/dev/null
 matrix:
   allow_failures:
+    - env: SKIP_TESTS_FROM=/dev/null
     - rust: nightly
 script:
   - cargo build --verbose
   - cargo test --verbose
   - cd tests
   - cmake -DEDITORCONFIG_CMD=`pwd`/../target/debug/editorconfig .
-  - ctest . -E $(cat ../test_skip_regex.txt)
+  - ctest . -E $(cat $SKIP_TESTS_FROM)

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ script:
   - cargo build --verbose
   - cargo test --verbose
   - cd tests
-  - cmake -DEDITORCONFIG_CMD=`pwd`/../target/debug/editorconfig . -E $(cat ../test_skip_regex.txt)
+  - cmake -DEDITORCONFIG_CMD=`pwd`/../target/debug/editorconfig -E $(cat ../test_skip_regex.txt) .
   - ctest .

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,11 @@ license = "MIT"
 repository = "https://github.com/mrandri19/rust-editorconfig"
 description = "A crate that implements editorconfig"
 
+[[bin]]
+name = "editorconfig"
+doc = false
+
 [dependencies]
-rust-ini = "0.10.0"
+argparse = "0.2.1"
+regex = "0.2"
+ordermap = "0.2.10"

--- a/src/ini.rs
+++ b/src/ini.rs
@@ -1,0 +1,1066 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2014 Y. T. CHUNG
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Stolen from https://github.com/zonyitoo/rust-ini/blob/f07159558271721393a0cd62f1af6d92944b5bff/src/ini.rs
+// and adapted for editorconfig modifications to INI format
+
+//! Ini
+
+use std::fs::{OpenOptions, File};
+use std::ops::{Index, IndexMut};
+use std::char;
+use std::io::{self, Write, Read};
+use std::fmt::{self, Display};
+use std::path::Path;
+use std::str::Chars;
+use std::borrow::Borrow;
+use std::hash::Hash;
+use std::cmp::Eq;
+use std::error;
+
+use ordermap::OrderMap;
+use ordermap::{Iter, IterMut, IntoIter, Keys, Entry};
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum EscapePolicy {
+    /// escape absolutely nothing (dangerous)
+    Nothing,
+    /// only escape the most necessary things
+    Basics,
+    /// escape basics and non-ascii characters
+    BasicsUnicode,
+    /// Escape reserved symbols.
+    Reserved,
+    /// Escape reserved symbols and non-ascii characters
+    ReservedUnicode,
+    /// Escape everything that some INI implementations assume
+    Everything,
+}
+
+impl EscapePolicy {
+    fn escape_basics(&self) -> bool {
+        match *self {
+            EscapePolicy::Nothing => false,
+            _ => true,
+        }
+    }
+
+    fn escape_reserved(&self) -> bool {
+        match *self {
+            EscapePolicy::Reserved => true,
+            EscapePolicy::ReservedUnicode => true,
+            EscapePolicy::Everything => true,
+            _ => false,
+        }
+    }
+
+    fn escape_unicode(&self) -> bool {
+        match *self {
+            EscapePolicy::BasicsUnicode => true,
+            EscapePolicy::ReservedUnicode => true,
+            EscapePolicy::Everything => true,
+            _ => false,
+        }
+    }
+
+    /// Given a character this returns true if it should be escaped as
+    /// per this policy or false if not.
+    pub fn should_escape(&self, c: char) -> bool {
+        match c {
+            '\\' |
+            '\x00'...'\x1f' |
+            '\x7f'...'\u{00ff}' => self.escape_basics(),
+            ';' | '#' | '=' | ':' => self.escape_reserved(),
+            '\u{0080}'...'\u{FFFF}' => self.escape_unicode(),
+            _ => false,
+        }
+    }
+}
+
+// Escape non-INI characters
+//
+// Common escape sequences: https://en.wikipedia.org/wiki/INI_file#Escape_characters
+//
+// * `\\` \ (a single backslash, escaping the escape character)
+// * `\0` Null character
+// * `\a` Bell/Alert/Audible
+// * `\b` Backspace, Bell character for some applications
+// * `\t` Tab character
+// * `\r` Carriage return
+// * `\n` Line feed
+// * `\;` Semicolon
+// * `\#` Number sign
+// * `\=` Equals sign
+// * `\:` Colon
+// * `\x????` Unicode character with hexadecimal code point corresponding to ????
+fn escape_str(s: &str, policy: EscapePolicy) -> String {
+    let mut escaped: String = String::with_capacity(s.len());
+    for c in s.chars() {
+        // if we know this is not something to escape as per policy, we just
+        // write it and continue.
+        if !policy.should_escape(c) {
+            escaped.push(c);
+            continue;
+        }
+
+        match c {
+            '\\' => escaped.push_str("\\\\"),
+            '\0' => escaped.push_str("\\0"),
+            '\x01'...'\x06' |
+            '\x0e'...'\x1f' |
+            '\x7f'...'\u{00ff}' => escaped.push_str(&format!("\\x{:04x}", c as isize)[..]),
+            '\x07' => escaped.push_str("\\a"),
+            '\x08' => escaped.push_str("\\b"),
+            '\x0c' => escaped.push_str("\\f"),
+            '\x0b' => escaped.push_str("\\v"),
+            '\n' => escaped.push_str("\\n"),
+            '\t' => escaped.push_str("\\t"),
+            '\r' => escaped.push_str("\\r"),
+            '\u{0080}'...'\u{FFFF}' => escaped.push_str(&format!("\\x{:04x}", c as isize)[..]),
+            _ => {
+                escaped.push('\\');
+                escaped.push(c);
+            }
+        }
+    }
+    escaped
+}
+
+/// A setter which could be used to set key-value pair in a specified section
+pub struct SectionSetter<'a> {
+    ini: &'a mut Ini,
+    section_name: Option<String>,
+}
+
+impl<'a> SectionSetter<'a> {
+    fn new(ini: &'a mut Ini, section_name: Option<String>) -> SectionSetter<'a> {
+        SectionSetter {
+            ini: ini,
+            section_name: section_name,
+        }
+    }
+
+    /// Set key-value pair in this section
+    pub fn set<K, V>(&'a mut self, key: K, value: V) -> &'a mut SectionSetter<'a>
+        where K: Into<String>,
+              V: Into<String>
+    {
+        {
+            let prop = match self.ini.sections.entry(self.section_name.clone()) {
+                Entry::Vacant(entry) => entry.insert(OrderMap::new()),
+                Entry::Occupied(entry) => entry.into_mut(),
+            };
+            prop.insert(key.into(), value.into());
+        }
+        self
+    }
+
+    /// Delete the entry in this section with `key`
+    pub fn delete<K>(&'a mut self, key: &K) -> &'a mut SectionSetter<'a>
+        where String: Borrow<K>,
+              K: Hash + Eq
+    {
+        if let Some(prop) = self.ini.sections.get_mut(&self.section_name) {
+            prop.remove(key);
+        }
+        self
+    }
+
+    /// Get the entry in this section with `key`
+    pub fn get<K>(&'a mut self, key: &K) -> Option<&'a str>
+        where String: Borrow<K>,
+              K: Hash + Eq
+    {
+        self.ini
+            .sections
+            .get(&self.section_name)
+            .and_then(|prop| prop.get(key).map(|s| &s[..]))
+    }
+}
+
+/// Properties type (key-value pairs)
+pub type Properties = OrderMap<String, String>; // Key-value pairs
+
+/// Ini struct
+#[derive(Clone, Debug)]
+pub struct Ini {
+    sections: OrderMap<Option<String>, Properties>,
+}
+
+impl Ini {
+    /// Create an instance
+    pub fn new() -> Ini {
+        Ini { sections: OrderMap::new() }
+    }
+
+    /// Set with a specified section, `None` is for the general section
+    pub fn with_section<'b, S>(&'b mut self, section: Option<S>) -> SectionSetter<'b>
+        where S: Into<String>
+    {
+        SectionSetter::new(self, section.map(|s| s.into()))
+    }
+
+    /// Get the immmutable general section
+    pub fn general_section(&self) -> &Properties {
+        self.section(None::<String>).expect("There is no general section in this Ini")
+    }
+
+    /// Get the mutable general section
+    pub fn general_section_mut(&mut self) -> &mut Properties {
+        self.section_mut(None::<String>).expect("There is no general section in this Ini")
+    }
+
+    /// Get a immutable section
+    pub fn section<'a, S>(&'a self, name: Option<S>) -> Option<&'a Properties>
+        where S: Into<String>
+    {
+        self.sections.get(&name.map(|s| s.into()))
+    }
+
+    /// Get a mutable section
+    pub fn section_mut<'a, S>(&'a mut self, name: Option<S>) -> Option<&'a mut Properties>
+        where S: Into<String>
+    {
+        self.sections.get_mut(&name.map(|s| s.into()))
+    }
+
+    /// Get the entry
+    pub fn entry<'a>(&'a mut self, name: Option<String>) -> Entry<Option<String>, Properties> {
+        self.sections.entry(name.map(|s| s.into()))
+    }
+
+    /// Clear all entries
+    pub fn clear<'a>(&mut self) {
+        self.sections.clear()
+    }
+
+    /// Iterate with sections
+    pub fn sections<'a>(&'a self) -> Keys<'a, Option<String>, Properties> {
+        self.sections.keys()
+    }
+
+    /// Set key-value to a section
+    pub fn set_to<S>(&mut self, section: Option<S>, key: String, value: String)
+        where S: Into<String>
+    {
+        self.with_section(section).set(key, value);
+    }
+
+    /// Get the value from a section with key
+    ///
+    /// Example:
+    ///
+    /// ```rust,ignore
+    /// use ini::Ini;
+    /// let input = "[sec]\nabc = def\n";
+    /// let ini = Ini::load_from_str(input).unwrap();
+    /// assert_eq!(ini.get_from(Some("sec"), "abc"), Some("def"));
+    /// ```
+    pub fn get_from<'a, S>(&'a self, section: Option<S>, key: &str) -> Option<&'a str>
+        where S: Into<String>
+    {
+        match self.sections.get(&section.map(|s| s.into())) {
+            None => None,
+            Some(ref prop) => {
+                match prop.get(key) {
+                    Some(p) => Some(&p[..]),
+                    None => None,
+                }
+            }
+        }
+    }
+
+    /// Get the value from a section with key, return the default value if it does not exist
+    ///
+    /// Example:
+    ///
+    /// ```rust,ignore
+    /// use ini::Ini;
+    /// let input = "[sec]\n";
+    /// let ini = Ini::load_from_str(input).unwrap();
+    /// assert_eq!(ini.get_from_or(Some("sec"), "key", "default"), "default");
+    /// ```
+    pub fn get_from_or<'a, S>(&'a self, section: Option<S>, key: &str, default: &'a str) -> &'a str
+        where S: Into<String>
+    {
+        match self.sections.get(&section.map(|s| s.into())) {
+            None => default,
+            Some(ref prop) => {
+                match prop.get(key) {
+                    Some(p) => &p[..],
+                    None => default,
+                }
+            }
+        }
+    }
+
+    /// Get the mutable from a section with key
+    pub fn get_from_mut<'a, S>(&'a mut self, section: Option<S>, key: &str) -> Option<&'a str>
+        where S: Into<String>
+    {
+        match self.sections.get_mut(&section.map(|s| s.into())) {
+            None => None,
+            Some(mut prop) => prop.get_mut(key).map(|s| &s[..]),
+        }
+    }
+
+    /// Delete a section, return the properties if it exists
+    pub fn delete<S>(&mut self, section: Option<S>) -> Option<Properties>
+        where S: Into<String>
+    {
+        self.sections.remove(&section.map(|s| s.into()))
+    }
+
+    pub fn delete_from<S>(&mut self, section: Option<S>, key: &str) -> Option<String>
+        where S: Into<String>
+    {
+        match self.section_mut(section) {
+            None => return None,
+            Some(prop) => prop.remove(key),
+        }
+    }
+}
+
+impl<'q> Index<&'q Option<String>> for Ini {
+    type Output = Properties;
+
+    fn index<'a>(&'a self, index: &'q Option<String>) -> &'a Properties {
+        match self.sections.get(index) {
+            Some(p) => p,
+            None => panic!("Section `{:?}` does not exist", index),
+        }
+    }
+}
+
+impl<'i> IndexMut<&'i Option<String>> for Ini {
+    fn index_mut<'a>(&'a mut self, index: &Option<String>) -> &'a mut Properties {
+        match self.sections.get_mut(index) {
+            Some(p) => p,
+            None => panic!("Section `{:?}` does not exist", index),
+        }
+    }
+}
+
+impl<'q> Index<&'q str> for Ini {
+    type Output = Properties;
+
+    fn index<'a>(&'a self, index: &'q str) -> &'a Properties {
+        match self.sections.get(&Some(index.into())) {
+            Some(p) => p,
+            None => panic!("Section `{}` does not exist", index),
+        }
+    }
+}
+
+impl<'q> IndexMut<&'q str> for Ini {
+    fn index_mut<'a>(&'a mut self, index: &'q str) -> &'a mut Properties {
+        match self.sections.get_mut(&Some(index.into())) {
+            Some(p) => p,
+            None => panic!("Section `{}` does not exist", index),
+        }
+    }
+}
+
+impl Ini {
+    /// Write to a file
+    pub fn write_to_file<P: AsRef<Path>>(&self, filename: P) -> io::Result<()> {
+        self.write_to_file_policy(filename, EscapePolicy::Basics)
+    }
+
+    /// Write to a file
+    pub fn write_to_file_policy<P: AsRef<Path>>(&self,
+                                                filename: P,
+                                                policy: EscapePolicy)
+                                                -> io::Result<()> {
+        let mut file = try!(OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .create(true)
+            .open(filename.as_ref()));
+        self.write_to_policy(&mut file, policy)
+    }
+
+    /// Write to a writer
+    pub fn write_to<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        self.write_to_policy(writer, EscapePolicy::Basics)
+    }
+
+    /// Write to a writer
+    pub fn write_to_policy<W: Write>(&self,
+                                     writer: &mut W,
+                                     policy: EscapePolicy)
+                                     -> io::Result<()> {
+        let mut firstline = true;
+
+        match self.sections.get(&None) {
+            Some(props) => {
+                for (k, v) in props.iter() {
+                    let k_str = escape_str(&k[..], policy);
+                    let v_str = escape_str(&v[..], policy);
+                    try!(write!(writer, "{}={}\n", k_str, v_str));
+                }
+                firstline = false;
+            }
+            None => {}
+        }
+
+        for (section, props) in self.sections.iter().filter(|&(ref s, _)| s.is_some()) {
+            if firstline {
+                firstline = false;
+            } else {
+                try!(writer.write_all(b"\n"));
+            }
+
+            if let &Some(ref section) = section {
+                try!(write!(writer, "[{}]\n", escape_str(&section[..], policy)));
+
+                for (k, v) in props.iter() {
+                    let k_str = escape_str(&k[..], policy);
+                    let v_str = escape_str(&v[..], policy);
+                    try!(write!(writer, "{}={}\n", k_str, v_str));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Ini {
+    /// Load from a string
+    pub fn load_from_str(buf: &str) -> Result<Ini, Error> {
+        let mut parser = Parser::new(buf.chars());
+        parser.parse()
+    }
+
+    /// Load from a reader
+    pub fn read_from<R: Read>(reader: &mut R) -> Result<Ini, Error> {
+        let mut s = String::new();
+        try!(reader.read_to_string(&mut s).map_err(|err| {
+            Error {
+                line: 0,
+                col: 0,
+                msg: format!("{}", err),
+            }
+        }));
+        let mut parser = Parser::new(s.chars());
+        parser.parse()
+    }
+
+    /// Load from a file
+    pub fn load_from_file<P: AsRef<Path>>(filename: P) -> Result<Ini, Error> {
+        let mut reader = match File::open(filename.as_ref()) {
+            Err(e) => {
+                return Err(Error {
+                    line: 0,
+                    col: 0,
+                    msg: format!("Unable to open `{:?}`: {}", filename.as_ref(), e),
+                })
+            }
+            Ok(r) => r,
+        };
+        Ini::read_from(&mut reader)
+    }
+}
+
+/// Iterator for sections
+pub struct SectionIterator<'a> {
+    mapiter: Iter<'a, Option<String>, Properties>,
+}
+
+/// Iterator for mutable sections
+pub struct SectionMutIterator<'a> {
+    mapiter: IterMut<'a, Option<String>, Properties>,
+}
+
+impl<'a> Ini {
+    /// Immutable iterate though sections
+    pub fn iter(&'a self) -> SectionIterator<'a> {
+        SectionIterator { mapiter: self.sections.iter() }
+    }
+
+    /// Mutable iterate though sections
+    /// *Deprecated! Use `iter_mut` instead!*
+    pub fn mut_iter(&'a mut self) -> SectionMutIterator<'a> {
+        SectionMutIterator { mapiter: self.sections.iter_mut() }
+    }
+
+    /// Mutable iterate though sections
+    pub fn iter_mut(&'a mut self) -> SectionMutIterator<'a> {
+        SectionMutIterator { mapiter: self.sections.iter_mut() }
+    }
+}
+
+impl<'a> Iterator for SectionIterator<'a> {
+    type Item = (&'a Option<String>, &'a Properties);
+
+    #[inline]
+    fn next(&mut self) -> Option<(&'a Option<String>, &'a Properties)> {
+        self.mapiter.next()
+    }
+}
+
+impl<'a> Iterator for SectionMutIterator<'a> {
+    type Item = (&'a Option<String>, &'a mut Properties);
+
+    #[inline]
+    fn next(&mut self) -> Option<(&'a Option<String>, &'a mut Properties)> {
+        self.mapiter.next()
+    }
+}
+
+impl<'a> IntoIterator for &'a Ini {
+    type Item = (&'a Option<String>, &'a Properties);
+    type IntoIter = SectionIterator<'a>;
+
+    fn into_iter(self) -> SectionIterator<'a> {
+        self.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut Ini {
+    type Item = (&'a Option<String>, &'a mut Properties);
+    type IntoIter = SectionMutIterator<'a>;
+
+    fn into_iter(self) -> SectionMutIterator<'a> {
+        self.iter_mut()
+    }
+}
+
+pub struct SectionIntoIter {
+    iter: IntoIter<Option<String>, Properties>,
+}
+
+impl Iterator for SectionIntoIter {
+    type Item = (Option<String>, Properties);
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+}
+
+impl IntoIterator for Ini {
+    type Item = (Option<String>, Properties);
+    type IntoIter = SectionIntoIter;
+
+    fn into_iter(self) -> SectionIntoIter {
+        SectionIntoIter { iter: self.sections.into_iter() }
+    }
+}
+
+// Ini parser
+struct Parser<'a> {
+    ch: Option<char>,
+    rdr: Chars<'a>,
+    line: usize,
+    col: usize,
+}
+
+#[derive(Debug)]
+/// Parse error
+pub struct Error {
+    pub line: usize,
+    pub col: usize,
+    pub msg: String,
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}:{} {}", self.line, self.col, self.msg)
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        self.msg.as_str()
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        None
+    }
+}
+
+impl<'a> Parser<'a> {
+    // Create a parser
+    pub fn new(rdr: Chars<'a>) -> Parser<'a> {
+        let mut p = Parser {
+            ch: None,
+            line: 0,
+            col: 0,
+            rdr: rdr,
+        };
+        p.bump();
+        p
+    }
+
+    fn eof(&self) -> bool {
+        self.ch.is_none()
+    }
+
+    fn bump(&mut self) {
+        self.ch = self.rdr.next();
+        match self.ch {
+            Some('\n') => {
+                self.line += 1;
+                self.col = 0;
+            }
+            Some(..) => {
+                self.col += 1;
+            }
+            None => {}
+        }
+    }
+
+    fn error<U>(&self, msg: String) -> Result<U, Error> {
+        Err(Error {
+            line: self.line,
+            col: self.col,
+            msg: msg.clone(),
+        })
+    }
+
+    /// Consume all the white space until the end of the line or a tab
+    fn parse_whitespace(&mut self) {
+        while let Some(c) = self.ch {
+            if !c.is_whitespace() && c != '\n' && c != '\t' && c != '\r' {
+                break;
+            }
+            self.bump();
+        }
+    }
+
+    /// Consume all the white space except line break
+    fn parse_whitespace_except_line_break(&mut self) {
+        while let Some(c) = self.ch {
+            if (c == '\n' || c == '\r' || !c.is_whitespace()) && c != '\t' {
+                break;
+            }
+            self.bump();
+        }
+    }
+
+    /// Parse the whole INI input
+    pub fn parse(&mut self) -> Result<Ini, Error> {
+        let mut result = Ini::new();
+        let mut curkey: String = "".into();
+        let mut cursec: Option<String> = None;
+
+        self.parse_whitespace();
+        while let Some(cur_ch) = self.ch {
+            match cur_ch {
+                ';' | '#' => {
+                    self.parse_comment();
+                }
+                '[' => {
+                    match self.parse_section() {
+                        Ok(sec) => {
+                            cursec = Some(sec.to_string());
+                            result.sections.entry(cursec.clone()).or_insert(OrderMap::new());
+                            self.parse_whitespace();
+                        }
+                        Err(e) => return Err(e),
+                    }
+                }
+                '=' | ':' => {
+                    if (&curkey[..]).is_empty() {
+                        return self.error("Missing key".to_string());
+                    }
+                    match self.parse_val() {
+                        Ok(val) => {
+                            let mval = val[..].trim().to_owned();
+                            let sec = result.sections
+                                .entry(cursec.clone())
+                                .or_insert(OrderMap::new());
+                            sec.insert(curkey, mval);
+                            curkey = "".into();
+                        }
+                        Err(e) => return Err(e),
+                    }
+                }
+                _ => {
+                    match self.parse_key() {
+                        Ok(key) => {
+                            let mkey: String = key[..].trim().to_owned();
+                            curkey = mkey.into();
+                        }
+                        Err(e) => return Err(e),
+                    }
+                }
+            }
+
+            self.parse_whitespace();
+        }
+
+        Ok(result)
+    }
+
+    fn parse_comment(&mut self) {
+        while let Some(c) = self.ch {
+            self.bump();
+            if c == '\n' {
+                break;
+            }
+        }
+    }
+
+    fn parse_str_until(&mut self, endpoint: &[Option<char>]) -> Result<String, Error> {
+        let mut result: String = String::new();
+
+        while !endpoint.contains(&self.ch) {
+            match self.ch {
+                None => {
+                    return self.error(format!("Expecting \"{:?}\" but found EOF.", endpoint));
+                }
+                Some('\\') => {
+                    self.bump();
+                    if self.eof() {
+                        return self.error(format!("Expecting \"{:?}\" but found EOF.", endpoint));
+                    }
+                    match self.ch.unwrap() {
+                        '0' => result.push('\0'),
+                        'a' => result.push('\x07'),
+                        'b' => result.push('\x08'),
+                        't' => result.push('\t'),
+                        'r' => result.push('\r'),
+                        'n' => result.push('\n'),
+                        '\n' => (),
+                        'x' => {
+                            // Unicode 4 character
+                            let mut code: String = String::with_capacity(4);
+                            for _ in 0..4 {
+                                self.bump();
+                                if self.eof() {
+                                    return self.error(format!("Expecting \"{:?}\" but found EOF.",
+                                                              endpoint));
+                                } else if let Some('\\') = self.ch {
+                                    self.bump();
+                                    if self.ch != Some('\n') {
+                                        return self.error(format!("Expecting \"\\\\n\" but \
+                                                                   found \"{:?}\".",
+                                                                  self.ch));
+                                    }
+                                }
+                                code.push(self.ch.unwrap());
+                            }
+                            let r = u32::from_str_radix(&code[..], 16);
+                            match r {
+                                Ok(c) => result.push(char::from_u32(c).unwrap()),
+                                Err(_) => return self.error("Unknown character.".to_string()),
+                            }
+                        },
+                        ';' => result.push(';'),
+                        '#' => result.push('#'),
+                        c => {
+                            result.push('\\');
+                            result.push(c)
+                        },
+                    }
+                }
+                Some(c) => {
+                    result.push(c);
+                }
+            }
+            self.bump();
+        }
+        Ok(result)
+    }
+
+    fn parse_section(&mut self) -> Result<String, Error> {
+        // Skip [
+        self.bump();
+        self.parse_str_until(&[Some('\n'), Some(';'), Some('#'), None]).map(|mut n| {
+            n = n.trim().to_string();
+            n.pop();
+            n
+        })
+    }
+
+    fn parse_key(&mut self) -> Result<String, Error> {
+        self.parse_str_until(&[Some('='), Some(':')])
+    }
+
+    fn parse_val(&mut self) -> Result<String, Error> {
+        self.bump();
+        // Issue #35: Allow empty value
+        self.parse_whitespace_except_line_break();
+
+        match self.ch {
+            None => Ok(String::new()),
+            Some('"') => {
+                self.bump();
+                self.parse_str_until(&[Some('"')]).and_then(|s| {
+                    self.bump(); // Eats the last "
+                    Ok(s)
+                })
+            }
+            Some('\'') => {
+                self.bump();
+                self.parse_str_until(&[Some('\'')]).and_then(|s| {
+                    self.bump(); // Eats the last '
+                    Ok(s)
+                })
+            }
+            _ => self.parse_str_until(&[Some('\n'), Some('\r'), Some(';'), Some('#'), None]),
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test {
+    use ini::*;
+
+    #[test]
+    fn load_from_str_with_valid_input() {
+        let input = "[sec1]\nkey1=val1\nkey2=377\n[sec2]foo=bar\n";
+        let opt = Ini::load_from_str(input);
+        assert!(opt.is_ok());
+
+        let output = opt.unwrap();
+        assert_eq!(output.sections.len(), 2);
+        assert!(output.sections.contains_key(&Some("sec1".into())));
+
+        let sec1 = &output.sections[&Some("sec1".into())];
+        assert_eq!(sec1.len(), 2);
+        let key1: String = "key1".into();
+        assert!(sec1.contains_key(&key1));
+        let key2: String = "key2".into();
+        assert!(sec1.contains_key(&key2));
+        let val1: String = "val1".into();
+        assert_eq!(sec1[&key1], val1);
+        let val2: String = "377".into();
+        assert_eq!(sec1[&key2], val2);
+
+    }
+
+    #[test]
+    fn load_from_str_without_ending_newline() {
+        let input = "[sec1]\nkey1=val1\nkey2=377\n[sec2]foo=bar";
+        let opt = Ini::load_from_str(input);
+        assert!(opt.is_ok());
+    }
+
+    #[test]
+    fn test_parse_comment() {
+        let input = "; abcdefghijklmn\n";
+        let opt = Ini::load_from_str(input);
+        assert!(opt.is_ok());
+    }
+
+    #[test]
+    fn test_inline_comment() {
+        let input = "
+[section name]
+name = hello # abcdefg
+gender = mail ; abdddd
+";
+        let ini = Ini::load_from_str(input).unwrap();
+        assert_eq!(ini.get_from(Some("section name"), "name").unwrap(), "hello");
+    }
+
+    #[test]
+    fn test_sharp_comment() {
+        let input = "
+[section name]
+name = hello
+# abcdefg
+";
+        let ini = Ini::load_from_str(input).unwrap();
+        assert_eq!(ini.get_from(Some("section name"), "name").unwrap(), "hello");
+    }
+
+    #[test]
+    fn test_iter() {
+        let input = "
+[section name]
+name = hello # abcdefg
+gender = mail ; abdddd
+";
+        let mut ini = Ini::load_from_str(input).unwrap();
+
+        for (_, _) in &mut ini {}
+        for (_, _) in &ini {}
+        for (_, _) in ini {}
+    }
+
+    #[test]
+    fn test_colon() {
+        let input = "
+[section name]
+name: hello # abcdefg
+gender : mail ; abdddd
+";
+        let ini = Ini::load_from_str(input).unwrap();
+        assert_eq!(ini.get_from(Some("section name"), "name").unwrap(), "hello");
+        assert_eq!(ini.get_from(Some("section name"), "gender").unwrap(),
+                   "mail");
+    }
+
+    #[test]
+    fn test_string() {
+        let input = "
+[section name]
+# This is a comment
+Key = \"Value\"
+";
+        let ini = Ini::load_from_str(input).unwrap();
+        assert_eq!(ini.get_from(Some("section name"), "Key").unwrap(), "Value");
+    }
+
+    #[test]
+    fn test_string_multiline() {
+        let input = "
+[section name]
+# This is a comment
+Key = \"Value
+Otherline\"
+";
+        let ini = Ini::load_from_str(input).unwrap();
+        assert_eq!(ini.get_from(Some("section name"), "Key").unwrap(),
+                   "Value\nOtherline");
+    }
+
+    #[test]
+    fn test_string_comment() {
+        let input = "
+[section name]
+# This is a comment
+Key = \"Value   # This is not a comment ; at all\"
+Stuff = Other
+";
+        let ini = Ini::load_from_str(input).unwrap();
+        assert_eq!(ini.get_from(Some("section name"), "Key").unwrap(),
+                   "Value   # This is not a comment ; at all");
+    }
+
+    #[test]
+    fn test_string_single() {
+        let input = "
+[section name]
+# This is a comment
+Key = 'Value'
+Stuff = Other
+";
+        let ini = Ini::load_from_str(input).unwrap();
+        assert_eq!(ini.get_from(Some("section name"), "Key").unwrap(), "Value");
+    }
+
+    #[test]
+    fn test_string_includes_quote() {
+        let input = "
+[Test]
+Comment[tr]=İnternet'e erişin
+Comment[uk]=Доступ до Інтернету
+";
+        let ini = Ini::load_from_str(input).unwrap();
+        assert_eq!(ini.get_from(Some("Test"), "Comment[tr]").unwrap(),
+                   "İnternet'e erişin");
+    }
+
+    #[test]
+    fn test_string_single_multiline() {
+        let input = "
+[section name]
+# This is a comment
+Key = 'Value
+Otherline'
+Stuff = Other
+";
+        let ini = Ini::load_from_str(input).unwrap();
+        assert_eq!(ini.get_from(Some("section name"), "Key").unwrap(),
+                   "Value\nOtherline");
+    }
+
+    #[test]
+    fn test_string_single_comment() {
+        let input = "
+[section name]
+# This is a comment
+Key = 'Value   # This is not a comment ; at all'
+";
+        let ini = Ini::load_from_str(input).unwrap();
+        assert_eq!(ini.get_from(Some("section name"), "Key").unwrap(),
+                   "Value   # This is not a comment ; at all");
+    }
+
+    #[test]
+    fn load_from_str_with_valid_empty_input() {
+        let input = "key1=\nkey2=val2\n";
+        let opt = Ini::load_from_str(input);
+        assert!(opt.is_ok());
+
+        let output = opt.unwrap();
+        assert_eq!(output.sections.len(), 1);
+        assert!(output.sections.contains_key(&None::<String>));
+
+        let sec1 = &output.sections[&None::<String>];
+        assert_eq!(sec1.len(), 2);
+        let key1: String = "key1".into();
+        assert!(sec1.contains_key(&key1));
+        let key2: String = "key2".into();
+        assert!(sec1.contains_key(&key2));
+        let val1: String = "".into();
+        assert_eq!(sec1[&key1], val1);
+        let val2: String = "val2".into();
+        assert_eq!(sec1[&key2], val2);
+    }
+
+    #[test]
+    fn load_from_str_with_crlf() {
+        let input = "key1=val1\r\nkey2=val2\r\n";
+        let opt = Ini::load_from_str(input);
+        assert!(opt.is_ok());
+
+        let output = opt.unwrap();
+        assert_eq!(output.sections.len(), 1);
+        assert!(output.sections.contains_key(&None::<String>));
+        let sec1 = &output.sections[&None::<String>];
+        assert_eq!(sec1.len(), 2);
+        let key1: String = "key1".into();
+        assert!(sec1.contains_key(&key1));
+        let key2: String = "key2".into();
+        assert!(sec1.contains_key(&key2));
+        let val1: String = "val1".into();
+        assert_eq!(sec1[&key1], val1);
+        let val2: String = "val2".into();
+        assert_eq!(sec1[&key2], val2);
+    }
+
+    #[test]
+    fn load_from_str_with_cr() {
+        let input = "key1=val1\rkey2=val2\r";
+        let opt = Ini::load_from_str(input);
+        assert!(opt.is_ok());
+
+        let output = opt.unwrap();
+        assert_eq!(output.sections.len(), 1);
+        assert!(output.sections.contains_key(&None::<String>));
+        let sec1 = &output.sections[&None::<String>];
+        assert_eq!(sec1.len(), 2);
+        let key1: String = "key1".into();
+        assert!(sec1.contains_key(&key1));
+        let key2: String = "key2".into();
+        assert!(sec1.contains_key(&key2));
+        let val1: String = "val1".into();
+        assert_eq!(sec1[&key1], val1);
+        let val2: String = "val2".into();
+        assert_eq!(sec1[&key2], val2);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,7 @@ fn parse_config(target: &Path, conf_file: &Path) -> Result<OrderMap<String, Stri
         }
     }
     let target = target.as_os_str().to_os_string().into_string().unwrap();
+    #[cfg(windows)]
     let target = target.replace("\\", "/");
     for (label, data) in ini_data.iter() {
         if let Some(ref label) = *label {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,17 @@
 //! A crate that implements [editorconfig](http://editorconfig.org/).
-extern crate ini;
+extern crate regex;
+extern crate ordermap;
+mod ini;
 use ini::Ini;
+use regex::{Regex, Captures};
+use ordermap::OrderMap;
 
 use std::path::{Path, PathBuf};
 use std::fs::read_dir;
 use std::ffi::OsString;
-fn editorconfig_is_root(file_path: &Path) -> Result<bool, ini::ini::Error> {
+use std::io;
+use std::error::Error;
+fn editorconfig_is_root(file_path: &Path) -> Result<bool, ini::Error> {
     let cfg = Ini::load_from_file(file_path)?;
     if let Some(root) = cfg.get_from::<String>(None, "root") {
         if root == "true" {
@@ -15,7 +21,19 @@ fn editorconfig_is_root(file_path: &Path) -> Result<bool, ini::ini::Error> {
     Ok(false)
 }
 
-fn search_dir_for_editorconfig(search_path: &Path) -> std::io::Result<PathBuf> {
+fn crawl_paths(path: &Path, conffile: &str) -> Vec<PathBuf> {
+    let mut path = path.to_path_buf();
+    let mut result = vec![];
+    while path.parent().is_some() {
+        let mut adjacent_file = path.clone();
+        adjacent_file.set_file_name(conffile);
+        result.push(adjacent_file);
+        path.pop();
+    }
+    return result;
+}
+
+fn search_dir_for_editorconfig(search_path: &Path) -> io::Result<PathBuf> {
     // If we are given a relative refernece we need to make it absolute to be able to traverse until root
     let absolute_path = if search_path.is_relative() {
         search_path.canonicalize()?
@@ -62,6 +80,95 @@ fn search_dir_for_editorconfig(search_path: &Path) -> std::io::Result<PathBuf> {
     }
 }
 
+fn glob_match(pattern: &String, candidate: &String) -> bool {
+    // Step 1. Escape the crap out of the existing pattern
+    // println!("B: {}", pattern);
+    let pattern = pattern.replace(".", r"\.");
+    let unmatched_open_bracket_regex = Regex::new(r"\[([^\]]*)$").unwrap();
+    let pattern = unmatched_open_bracket_regex.replace(&pattern, r"\[$1").to_string();
+    // Step 2. Convert sh globs to regexes
+    // Handling * and ** is weird but this actually works
+    let pattern = pattern.replace("*", "[^/]*");
+    let pattern = pattern.replace("[^/]*[^/]*", ".*");
+    let pattern = pattern.replace("?", ".");
+    let pattern = pattern.replace("[!", "[^");
+    let alternation_regex = Regex::new(r"\{(.*,.*)\}").unwrap();
+    let pattern = alternation_regex.replace(&pattern, |caps: &Captures| {
+        let padded_cases = format!(",{},", &caps[1]);
+        let quantifier = if padded_cases.contains(",,") {
+            "?"
+        } else {
+            ""
+        };
+        let cases = caps[1].replace(",", "|");
+        format!("({}){}", cases, quantifier)
+    }).to_string();
+    let pattern = pattern.replace("{", r"\{");
+    let pattern = pattern.replace("}", r"\}");
+    let pattern = pattern.replace("||", "|");
+    let pattern = pattern.replace("(|", "(");
+    let pattern = pattern.replace("|)", ")");
+    let mut pattern = pattern;
+    pattern.push('$');
+    // println!("A: {}", pattern);
+    // Step 3. Actually do the testing
+    let final_regex = Regex::new(&pattern).unwrap();
+    return final_regex.is_match(candidate);
+}
+
+fn parse_config(target: &Path, conf_file: &Path) -> Result<OrderMap<String, String>, Box<Error>> {
+    let ini_data = ini::Ini::load_from_file(conf_file)?;
+    let mut result = OrderMap::new();
+    if let Some(general) = ini_data.section::<String>(None) {
+        if let Some(root) = general.get("root") {
+            if root.to_lowercase() == "true" {
+                result.insert("root".to_string(), "true".to_string());
+            }
+        }
+    }
+    let target = target.as_os_str().to_os_string().into_string().unwrap();
+    let target = target.replace("\\", "/");
+    for (label, data) in ini_data.iter() {
+        if let Some(ref label) = *label {
+            if label.len() > 4096 {
+                continue;
+            }
+            if glob_match(label, &target) {
+                for (k, v) in data.iter() {
+                    result.insert(k.clone(), v.clone());
+                }
+            }
+        }
+    }
+    
+    // Preprocessing may or may not actually be part of the spec
+    // so I'm stealing this from editorconfig-core-py
+    if let Some(indent_style) = result.clone().get("indent_style") {
+        if indent_style == "tab" {
+            if result.get("indent_size").is_none() {
+                result.insert("indent_size".to_string(), "tab".to_string());
+            }
+        }
+    }
+    if let Some(indent_size) = result.clone().get("indent_size") {
+        if indent_size != "tab" {
+            if result.get("tab_width").is_none() {
+                result.insert("tab_width".to_string(), indent_size.clone());
+            }
+        } else {
+            if let Some(tab_width) = result.clone().get("tab_width") {
+                result.insert("indent_size".to_string(), tab_width.clone());
+            }
+        }
+    }
+    Ok(result)
+}
+
+fn is_known_key(key: &str) -> bool {
+    let known_keys = ["indent_style", "indent_size", "tab_width", "end_of_line", "charset", "trim_trailing_whitespace", "insert_final_newline"];
+    known_keys.contains(&key)
+}
+
 /// Searches for a `.editorconfig` file and returns a struct representing its content which can be iterated.
 ///
 /// The `file_path` argument can be the path to a directory or a file.
@@ -92,10 +199,51 @@ fn search_dir_for_editorconfig(search_path: &Path) -> std::io::Result<PathBuf> {
 ///
 /// - when the `file_path` is malformed
 ///
-pub fn get_editorconfig(file_path: &Path) -> Result<ini::Ini, Box<std::error::Error>> {
+pub fn get_editorconfig(file_path: &Path) -> Result<ini::Ini, Box<Error>> {
     let edc_path = search_dir_for_editorconfig(file_path)?;
     let edc = ini::Ini::load_from_file(edc_path)?;
     Ok(edc)
+}
+
+/// Finds actual configuration that applies to file with given path.
+///
+/// Parses .editorconfig data until root is found.
+pub fn get_config(file_path: &Path) -> Result<OrderMap<String, String>, Box<Error>> {
+    get_config_conffile(file_path, ".editorconfig")
+}
+
+/// Finds actual configuration that applies to file with given path.
+///
+/// Looks for config data in given filename; in normal operation this will be ".editorconfig".
+pub fn get_config_conffile(file_path: &Path, conffile: &str) -> Result<OrderMap<String, String>, Box<Error>> {
+    let paths = crawl_paths(file_path, conffile);
+    let mut result = OrderMap::new();
+    for conf_path in paths {
+        if !conf_path.exists() {
+            continue;
+        }
+        let options = parse_config(file_path, &conf_path)?;
+        for (k, v) in options.iter() {
+            let k = k.to_lowercase();
+            let v = if is_known_key(&k) {
+                v.to_lowercase()
+            } else {
+                v.clone()
+            };
+            if k.len() > 50 || v.len() > 255 {
+                continue;
+            }
+            if !result.contains_key(&k) && k != "root" {
+                result.insert(k, v);
+            }
+        }
+        if let Some(root) = options.get("root") {
+            if root.to_lowercase() == "true" {
+                break;
+            }
+        }
+    }
+    return Ok(result);
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,36 @@
+extern crate editorconfig;
+extern crate argparse;
+
+use editorconfig::*;
+use argparse::{ArgumentParser, Store, List};
+use std::path::Path;
+
+fn main() {
+    let mut conf_filename = ".editorconfig".to_string();
+    let mut version = "".to_string();
+    let mut targets: Vec<String> = vec![];
+    {
+        let mut ap = ArgumentParser::new();
+        ap.set_description("Parse .editorconfig files.");
+        ap.refer(&mut conf_filename)
+            .add_option(&["-f"], Store, "Conf filename");
+        ap.refer(&mut version)
+            .add_option(&["-b"], Store, "editorconfig version");
+        ap.refer(&mut targets)
+            .add_argument("arguments", List, "Files to check");
+        ap.parse_args_or_exit();
+    }
+    
+    let multiple_targets = targets.len() > 1;
+    
+    for t in targets {
+        if multiple_targets {
+            println!("[{}]", t);
+        }
+
+        let res = get_config_conffile(Path::new(&t), &conf_filename).unwrap();
+        for (k, v) in res.iter() {
+            println!("{}={}", *k, *v);
+        }
+    }
+}

--- a/test_skip_regex.txt
+++ b/test_skip_regex.txt
@@ -1,0 +1,1 @@
+(brackets_.*side|braces_unmatched|braces_escaped|braces_patterns_nested|braces_.*_range|star_star|pre_0_9_0|parent_and_current_dir|nested_path_separator|top_level_path_separator_neg|version_switch)


### PR DESCRIPTION
It looks like the official C, Python, JS, etc. editorconfig implementations have an API that lets you put in a path and get back the actual settings that apply to it, with filename patterns and root crawling handled by the API. That's what I was looking for, so I went ahead and added it.

editorconfig has official tests for their core implementations in various languages, so I went ahead and pulled those in and added them to the Travis configuration. The way those tests work is by running a binary that prints out the config values it finds for a given file, so I've added that binary as well.

editorconfig defines some extensions to the INI file format that the `rust-ini` crate doesn't support, but that crate is MIT licensed so I just dragged the source in and made some changes.

Not all of the official tests pass. Some failing tests are for backwards compatibility or weird syntax edge cases with special characters in filenames, but others are for recursive globs with `**` or other things that should really work. A few of the tests fail because the binary outputs things in the wrong order, but I fixed most of those and the only ones left are weird parent/child directory precedence issues. Those are running on Travis as well, but set to be allowed to fail.

The API documentation on `get_config` and `get_config_conffile` is a bit sparser than what you have on `get_editorconfig`. I can go in and write more there if you'd like.

If you'd rather not merge this until it can pass every single one of the official tests, I can spend more time trying to get those working.

I think I commented the parts that were the most confusing to write, but if there are parts of the code where it isn't clear what I did, I can go back in and write more thorough comments.