### PR TITLE
Fix most braces issues

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,21 @@ fn crawl_paths(path: &Path, conffile: &str) -> Result<Vec<PathBuf>, Box<Error>> 
     return Ok(result);
 }
 
+fn has_imbalanced_braces(text: &str) -> bool {
+    let mut depth = 0i32;
+    for c in text.chars() {
+        if c == '{' {
+            depth += 1;
+        } else if c == '}' {
+            depth -= 1;
+            if depth < 0 {
+                return true;
+            }
+        }
+    }
+    return depth != 0;
+}
+
 fn glob_match(pattern: &String, candidate: &String) -> bool {
     // Step 1. Escape the crap out of the existing pattern
     // println!("B: {}", pattern);
@@ -51,7 +66,7 @@ fn glob_match(pattern: &String, candidate: &String) -> bool {
     let pattern = pattern.replace("[!", "[^");
     let alternation_regex = Regex::new(r"\{(.*,.*)\}").unwrap();
     let pattern = alternation_regex.replace(&pattern, |caps: &Captures| {
-            if caps[1].starts_with("}") || caps[1].ends_with("{") {
+            if has_imbalanced_braces(&caps[1]) {
                 return format!("{{{}}}", &caps[1]);
             }
             let padded_cases = format!(",{},", &caps[1]);

--- a/test_skip_regex.txt
+++ b/test_skip_regex.txt
@@ -1,1 +1,1 @@
-(braces_escaped|braces_patterns_nested|braces_.*_range|pre_0_9_0|parent_and_current_dir|nested_path_separator)
+(braces_patterns_nested|braces_.*_range|pre_0_9_0|parent_and_current_dir|nested_path_separator)

--- a/test_skip_regex.txt
+++ b/test_skip_regex.txt
@@ -1,1 +1,1 @@
-(braces_patterns_nested|braces_.*_range|pre_0_9_0|parent_and_current_dir|nested_path_separator)
+(braces_.*_range|pre_0_9_0|parent_and_current_dir|nested_path_separator)

--- a/test_skip_regex.txt
+++ b/test_skip_regex.txt
@@ -1,1 +1,1 @@
-(braces_unmatched|braces_escaped|braces_patterns_nested|braces_.*_range|pre_0_9_0|parent_and_current_dir|nested_path_separator)
+(braces_escaped|braces_patterns_nested|braces_.*_range|pre_0_9_0|parent_and_current_dir|nested_path_separator)


### PR DESCRIPTION
The only braces-related tests that are still failing are the numeric range tests, which ensure that `{3..120}` matches numbers between 3 and 120. (The alpha range tests themselves aren't quite set up properly, but they're supposed to make sure that `{aardvark..antelope}` **doesn't** expand, which matches current behavior.)

This behavior isn't actually part of the editorconfig spec, and the [issue to add it](https://github.com/editorconfig/editorconfig/issues/82) hasn't seen activity since Feb 2013. It would still be nice to have it, but it's not really as important as the rest of the brace issues.